### PR TITLE
fix: missing documented 'oidc_provider_arn' variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create_oidc_provider"></a> [create\_oidc\_provider](#input\_create\_oidc\_provider) | Whether or not to create the associated oidc provider. If false, variable 'oidc\_provider\_arn' is required | `bool` | `true` | no |
+| <a name="input_oidc_provider_arn"></a> [oidc\_provider\_arn](#input\_oidc\_provider\_arn) | ARN of the OIDC provider to use. Required if 'create_oidc_provider' is false | `string` | `null` | no |
 | <a name="input_create_oidc_role"></a> [create\_oidc\_role](#input\_create\_oidc\_role) | Whether or not to create the OIDC attached role | `bool` | `true` | no |
 | <a name="input_github_thumbprint"></a> [github\_thumbprint](#input\_github\_thumbprint) | GitHub OpenID TLS certificate thumbprint. | `string` | `"6938fd4d98bab03faadb97b34396831e3780aea1"` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration in seconds. | `number` | `3600` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "create_oidc_provider" {
   default     = true
 }
 
+variable "oidc_provider_arn" {
+  description = "ARN of the OIDC provider to use. Required if 'create_oidc_provider' is false"
+  type        = string
+  default     = null
+}
+
 variable "create_oidc_role" {
   description = "Whether or not to create the OIDC attached role"
   type        = bool


### PR DESCRIPTION
## 📒 Description

I added the ability to provide an external `oidc_provider_arn` as shown in the README but not implemented yet.

## 🕶️ Types of changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation
- [ ] Dependencies

### 🔎 Review hints

You can use the module separately to check the feature:
- one usage of the module with `create_oidc_provider` = `true`
- one usage of the module with `create_oidc_provider` = `false` and `oidc_provider_arn` = `module.<previous_usage>.oidc_provider_arn`

## 🚨 Test instructions

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](../contributing.md).
- [ ] Added/updated unit tests for this change
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] My change requires a change to the documentation.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] Included links to related issues/PRs
