### PR TITLE
feat: Support GitHub Audit Log OIDC Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ module "github_oidc_audit_log" {
 
   // Policies attached to the role that will be assumed by the audit log consumer
   oidc_role_attach_policies = [
-    "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess" // Example policy
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess" // Example policy with s3:PutObject permission
   ]
   // Note: The 'repositories' variable is not used when github_provider is 'audit-log'.
 }

--- a/main.tf
+++ b/main.tf
@@ -5,13 +5,27 @@
  * This module allows you to create a Github OIDC provider for your AWS account, that will help Github Actions to securely authenticate against the AWS API using an IAM role
  *
 */
+
+locals {
+  github_oidc_providers = {
+    actions = {
+      url        = "https://token.actions.githubusercontent.com"
+      thumbprint = "6938fd4d98bab03faadb97b34396831e3780aea1"
+    }
+    audit-log = {
+      url        = "https://oidc-configuration.audit-log.githubusercontent.com"
+      thumbprint = "B0BC2A0F5F63E56BA1EB8E43A4CB2A053D20D433"
+    }
+  }
+}
+
 resource "aws_iam_openid_connect_provider" "this" {
   count = var.create_oidc_provider ? 1 : 0
   client_id_list = [
     "sts.amazonaws.com",
   ]
-  thumbprint_list = [var.github_thumbprint]
-  url             = "https://token.actions.githubusercontent.com"
+  thumbprint_list = [coalesce(var.github_thumbprint, local.github_oidc_providers[var.github_provider].thumbprint)]
+  url             = local.github_oidc_providers[var.github_provider].url
 }
 
 resource "aws_iam_role" "this" {
@@ -43,12 +57,30 @@ data "aws_iam_policy_document" "this" {
     effect  = "Allow"
 
     condition {
-      test   = "StringLike"
-      values = [
-        for repo in var.repositories :
-        "repo:%{if length(regexall(":+", repo)) > 0}${repo}%{else}${repo}:*%{endif}"
-      ]
-      variable = "token.actions.githubusercontent.com:sub"
+      test     = "StringEquals"
+      variable = "${replace(local.github_oidc_providers[var.github_provider].url, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    dynamic "condition" {
+      for_each = var.github_provider == "actions" && length(var.repositories) > 0 ? [1] : []
+      content {
+        test     = "StringLike"
+        variable = "${replace(local.github_oidc_providers["actions"].url, "https://", "")}:sub"
+        values = [
+          for repo in var.repositories :
+          "repo:%{if length(regexall(":+", repo)) > 0}${repo}%{else}${repo}:*%{endif}"
+        ]
+      }
+    }
+
+    dynamic "condition" {
+      for_each = var.github_provider == "audit-log" && var.enterprise_name != null ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "${replace(local.github_oidc_providers["audit-log"].url, "https://", "")}:sub"
+        values   = ["https://github.com/${var.enterprise_name}"]
+      }
     }
 
     principals {

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "create_oidc_role" {
 variable "github_thumbprint" {
   description = "GitHub OpenID TLS certificate thumbprint."
   type        = string
-  default     = "6938fd4d98bab03faadb97b34396831e3780aea1"
+  default     = null
 }
 
 variable "repositories" {
@@ -75,4 +75,20 @@ variable "role_description" {
   description = "(Optional) Description of the role."
   type        = string
   default     = "Role assumed by the GitHub OIDC provider."
+}
+
+variable "github_provider" {
+  description = "The GitHub OIDC provider type. Can be 'actions' or 'audit-log'."
+  type        = string
+  default     = "actions"
+  validation {
+    condition     = contains(["actions", "audit-log"], var.github_provider)
+    error_message = "Valid values for github_provider are 'actions' or 'audit-log'."
+  }
+}
+
+variable "enterprise_name" {
+  description = "The name of the enterprise to use when github_provider is 'audit-log'. The name is case-sensitive."
+  type        = string
+  default     = null
 }


### PR DESCRIPTION

# ↪️ Pull Request: Feature/Enhanced GitHub OIDC Provider Configuration

<!--
Put an `x` into the [ ] to show you have filled the information
-->

- [x] Make sure you are opening from a **feature/feat/docs/fix/bug/hotfix/stable/chore** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry

## 📒 Description

This pull request introduces support for multiple GitHub OIDC provider types ("actions" and "audit-log") and enhances the IAM role's trust policy conditions for more granular control. It allows users to configure the module for both standard GitHub Actions OIDC integration and GitHub Enterprise Audit Log streaming OIDC.

## 🕶️ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation
- [ ] Dependencies

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->
*   **Dual GitHub OIDC Provider Support:**
    *   Added `github_provider` input variable (`"actions"` or `"audit-log"`).
    *   OIDC provider URL and thumbprint are now dynamic based on `github_provider`.
    *   `thumbprint_list` uses `coalesce(var.github_thumbprint, local.github_oidc_providers[var.github_provider].thumbprint)` for override capability.
*   **Dynamic IAM Trust Policy Conditions:**
    *   Common condition: `${provider_url}:aud` equals `sts.amazonaws.com`.
    *   For `github_provider = "actions"`: Condition restricts `${actions_provider_url}:sub` to `var.repositories`.
    *   For `github_provider = "audit-log"`: Condition (requires `var.enterprise_name`) restricts `${audit_log_provider_url}:sub` to `https://github.com/${var.enterprise_name}`.
*   **New Input Variables:**
    *   `github_provider` (string, default: `"actions"`)
    *   `enterprise_name` (string, default: `null`, required for "audit-log" provider)
*   **Documentation (`README.md`) Updates:**
    *   Comprehensive updates reflecting new features.
    *   New "Provider Types and Conditions" section.
    *   Updated usage examples for "actions" and "audit-log".
    *   Note about running `terraform-docs`.

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

https://github.com/terraform-module/terraform-aws-github-oidc-provider/issues/129


### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
*   Verify the logic for selecting OIDC provider URL and thumbprint based on `var.github_provider` and `var.github_thumbprint`.
*   Check the conditional IAM policy statements for both "actions" and "audit-log" provider types, especially the handling of `var.repositories` and `var.enterprise_name`.
*   Ensure `README.md` accurately reflects the new functionality and input variables.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
1.  **Test "actions" provider (default):**
    *   Deploy the module without setting `github_provider` (or set to `"actions"`).
    *   Provide a list of `repositories`.
    *   Verify the created OIDC provider URL is `https://token.actions.githubusercontent.com`.
    *   Inspect the IAM role's trust policy:
        *   Condition for `token.actions.githubusercontent.com:aud` should be `sts.amazonaws.com`.
        *   Condition for `token.actions.githubusercontent.com:sub` should use `StringLike` and reference the provided `repositories`.
    *   Optionally, test overriding the thumbprint with `var.github_thumbprint`.
2.  **Test "audit-log" provider:**
    *   Deploy the module with `github_provider = "audit-log"`.
    *   Set `enterprise_name` to a test enterprise name.
    *   Verify the created OIDC provider URL is `https://oidc-configuration.audit-log.githubusercontent.com`.
    *   Inspect the IAM role's trust policy:
        *   Condition for `oidc-configuration.audit-log.githubusercontent.com:aud` should be `sts.amazonaws.com`.
        *   Condition for `oidc-configuration.audit-log.githubusercontent.com:sub` should use `StringEquals` and reference `https://github.com/YOUR_ENTERPRISE_NAME`.
    *   Test that deployment fails if `enterprise_name` is not provided when `github_provider` is "audit-log" (if validation for this is in place, or consider adding it).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](../contributing.md).
- [ ] Added/updated unit tests for this change
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] My change requires a change to the documentation.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] Included links to related issues/PRs