### PR TITLE
feat: support immutable OIDC subject format in repositories validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,37 @@ module "github-oidc" {
 }
 ```
 
+### Immutable subject claims
+
+GitHub issues OIDC tokens whose `sub` claim uses an immutable format that embeds
+the numeric owner and repository IDs for repositories created or transferred
+after 2026-07-15 (`repo:OWNER@OWNER-ID/REPO@REPO-ID:...`). This module accepts
+that format in `repositories` alongside the classic name-based format, so you
+can mix both:
+
+```hcl
+module "github-oidc" {
+  source  = "terraform-module/github-oidc-provider/aws"
+  version = "~> 1"
+
+  create_oidc_provider = true
+  create_oidc_role     = true
+
+  repositories = [
+    # Classic name-based subject
+    "terraform-module/module-blueprint",
+    # Immutable subject (owner id 123456, repo id 789012)
+    "terraform-module@123456/module-blueprint@789012",
+  ]
+}
+```
+
+You can retrieve the immutable prefix for a repository from the
+`sub_claim_prefix` field of the
+`GET /repos/{owner}/{repo}/actions/oidc/customization/sub` REST API endpoint.
+See [Immutable subject claims](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims)
+for more information.
+
 ## Examples
 
 See `examples` directory for working examples to reference
@@ -117,7 +148,7 @@ No modules.
 | <a name="input_github_thumbprint"></a> [github\_thumbprint](#input\_github\_thumbprint) | GitHub OpenID TLS certificate thumbprint. | `string` | `"6938fd4d98bab03faadb97b34396831e3780aea1"` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration in seconds. | `number` | `3600` | no |
 | <a name="input_oidc_role_attach_policies"></a> [oidc\_role\_attach\_policies](#input\_oidc\_role\_attach\_policies) | Attach policies to OIDC role. | `list(string)` | `[]` | no |
-| <a name="input_repositories"></a> [repositories](#input\_repositories) | List of GitHub organization/repository names authorized to assume the role. | `list(string)` | `[]` | no |
+| <a name="input_repositories"></a> [repositories](#input\_repositories) | List of GitHub organization/repository names authorized to assume the role. Both the classic `organization/repository` format and the immutable subject format `organization@owner-id/repository@repo-id` (used by GitHub for repositories created/transferred after 2026-07-15) are supported. | `list(string)` | `[]` | no |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | (Optional) Description of the role. | `string` | `"Role assumed by the GitHub OIDC provider."` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | (Optional, Forces new resource) Friendly name of the role. | `string` | `"github-oidc-provider-aws"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -27,18 +27,28 @@ variable "github_thumbprint" {
 }
 
 variable "repositories" {
-  description = "List of GitHub organization/repository names authorized to assume the role."
+  description = <<-EOT
+    List of GitHub organization/repository names authorized to assume the role.
+    Both the classic name-based format (`organization/repository`) and the
+    immutable subject format that GitHub issues for repositories created or
+    transferred after 2026-07-15 (`organization@owner-id/repository@repo-id`)
+    are supported.
+    See https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims.
+  EOT
   type        = list(string)
   default     = []
 
   validation {
-    # Ensures each element of github_repositories list matches the
-    # organization/repository format used by GitHub.
+    # Ensures each element of the repositories list matches either the classic
+    # `organization/repository` format or the immutable-subject format
+    # `organization@owner-id/repository@repo-id` that GitHub uses for the
+    # `sub` claim of repositories created/transferred after 2026-07-15.
+    # An optional trailing context (e.g. `:ref:refs/heads/main`, `:*`) is allowed.
     condition = length([
       for repo in var.repositories : 1
-      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/-]+|\\*)$", repo)) > 0
+      if length(regexall("^[A-Za-z0-9_.-]+(@[0-9]+)?/([A-Za-z0-9_.:/@-]+|\\*)$", repo)) > 0
     ]) == length(var.repositories)
-    error_message = "Repositories must be specified in the organization/repository format."
+    error_message = "Repositories must be specified in the organization/repository or immutable organization@owner-id/repository@repo-id format."
   }
 }
 


### PR DESCRIPTION
# ↪️ Pull Request

- [x] Make sure you are opening from a **feature/feat/docs/fix/bug/hotfix/stable/chore** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry

## 📒 Description

GitHub is rolling out **immutable OIDC subject claims**. For repositories created or transferred after 2026-07-15, the `sub` claim no longer uses only the org/repo names — it embeds the numeric owner ID and repository ID, using `@` as the separator:

- Previous format: `repo:octo-org/octo-repo:ref:refs/heads/main`
- Immutable format: `repo:octo-org@123456/octo-repo@789012:ref:refs/heads/main`

(See [Immutable subject claims](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims).)

The `repositories` variable validation currently rejects the `@` character, so users cannot add these repositories to the trust policy and get:

> Repositories must be specified in the organization/repository format.

This PR relaxes the validation regex to accept **both** the classic `organization/repository` format and the immutable `organization@owner-id/repository@repo-id` format. No change is required in `main.tf`: the existing `aws_iam_policy_document` template already renders any colon-free entry as `repo:<value>:*`, so an immutable entry like `octo-org@123456/octo-repo@789012` correctly produces the condition `repo:octo-org@123456/octo-repo@789012:*`.

## 🕶️ Types of changes

- [ ] Core
- [x] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation
- [ ] Dependencies

### 🤯 List of changes

- `variables.tf`: updated the `repositories` validation regex from `^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/-]+|\*)$` to `^[A-Za-z0-9_.-]+(@[0-9]+)?/([A-Za-z0-9_.:/@-]+|\*)$`, adding an optional `@<owner-id>` after the org name and allowing `@` in the repository/context segment.
- `variables.tf`: expanded the variable `description` and validation `error_message` to document the immutable format.
- `README.md`: updated the inputs table and added an "Immutable subject claims" usage section with a mixed-format example and a pointer to the `GET /repos/{owner}/{repo}/actions/oidc/customization/sub` REST endpoint (`sub_claim_prefix`).

### 👫 Relationships

Closes #133

### 🔎 Review hints

- The core change is a single regex. It is backward compatible: all previously valid values (`org/repo`, `org/*`, `org/repo:ref:refs/heads/main`) still pass.
- `main.tf` is intentionally unchanged — the immutable value flows through the existing `%{if length(regexall(":+", repo)) > 0}...%{endif}` template and yields the correct `repo:...:*` subject.

## 🚨 Test instructions

Regex verified against representative valid/invalid inputs (all pass):

| Input | Expected |
|-------|----------|
| `octo-org/octo-repo` | ✅ valid |
| `octo-org@123456/octo-repo@789012` | ✅ valid |
| `octo-org/*` | ✅ valid |
| `octo-org/octo-repo:ref:refs/heads/main` | ✅ valid |
| `octo-org@123/octo-repo@456:ref:refs/heads/main` | ✅ valid |
| `justaname` | ❌ invalid |
| `owner/` | ❌ invalid |
| `` (empty) | ❌ invalid |

To reproduce end-to-end:

```hcl
module "github-oidc" {
  source = "../.."

  create_oidc_provider = true
  create_oidc_role     = true
  repositories = [
    "octo-org/octo-repo",                 # classic
    "octo-org@123456/octo-repo@789012",   # immutable
  ]
}